### PR TITLE
Use the mnemonic field in RAnalOp to avoid warnings in r2

### DIFF
--- a/libr/lang/p/python/anal.c
+++ b/libr/lang/p/python/anal.c
@@ -201,6 +201,7 @@ static int py_anal(RAnal *a, RAnalOp *op, ut64 addr, const ut8 *buf, int len, RA
 				READ_VAL(tmpdst, op->dst, tmpreg)
 				// Loading 'var' value if presented
 				r_strbuf_set (&op->esil, getS (dict, "esil"));
+				op->mnemonic = r_str_new (getS (dict, "mnemonic"));
 				// TODO: Add opex support here
 				Py_DECREF (dict);
 			}


### PR DESCRIPTION
Newer versions of r2 require the presence of `mnemonic` field in `RAnalOp` structures, and if it's missing - warnings appear on the screen. This PR adds support for this field in Python bindings.